### PR TITLE
CORE-67: migrate the library to CAS 5.3.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject org.cyverse/cyverse-cas-server-support-ldap-rfc2307 "1.0.2-SNAPSHOT"
+(defproject org.cyverse/cyverse-cas-server-support-ldap-rfc2307 "5.3.7-SNAPSHOT"
   :description "Plugin for the DataONE member node service."
   :license {:name "BSD"
             :url "http://www.cyverse.org/sites/default/files/iPLANT-LICENSE.txt"}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.apereo.cas/cas-server-core-authentication "5.2.0" :exclusions [com.nimbusds/lang-tag]]
-                 [org.apereo.cas/cas-server-core-configuration "5.2.0"]
-                 [org.apereo.cas/cas-server-support-ldap "5.2.0" :exclusions [com.nimbusds/lang-tag]]]
+                 [org.apereo.cas/cas-server-core-authentication "5.3.7" :exclusions [com.nimbusds/lang-tag]]
+                 [org.apereo.cas/cas-server-core-configuration "5.3.7"]
+                 [org.apereo.cas/cas-server-support-ldap "5.3.7" :exclusions [com.nimbusds/lang-tag]]]
   :source-paths ["src/main/clojure"]
   :resource-paths ["src/main/resources"]
   :java-source-paths ["src/main/java"]

--- a/src/main/java/org/cyverse/cas/ldap/rfc2307/authentication/Rfc2307LdapAuthenticationHandler.java
+++ b/src/main/java/org/cyverse/cas/ldap/rfc2307/authentication/Rfc2307LdapAuthenticationHandler.java
@@ -1,8 +1,8 @@
 package org.cyverse.cas.ldap.rfc2307.authentication;
 
+import org.apereo.cas.authentication.AuthenticationPasswordPolicyHandlingStrategy;
 import org.apereo.cas.authentication.LdapAuthenticationHandler;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
-import org.apereo.cas.authentication.support.LdapPasswordPolicyHandlingStrategy;
 import org.apereo.cas.services.ServicesManager;
 import org.cyverse.cas.ldap.rfc2307.config.Rfc2307LdapAuthenticationConfiguration;
 import org.cyverse.cas.ldap.rfc2307.util.GroupMembershipResolver;
@@ -38,7 +38,7 @@ public class Rfc2307LdapAuthenticationHandler extends LdapAuthenticationHandler 
      */
     public Rfc2307LdapAuthenticationHandler(
             String name, ServicesManager servicesManager, PrincipalFactory principalFactory, Integer order,
-            Authenticator authenticator, LdapPasswordPolicyHandlingStrategy strategy,
+            Authenticator authenticator, AuthenticationPasswordPolicyHandlingStrategy strategy,
             GroupMembershipResolver groupMembershipResolver) {
         super(name, servicesManager, principalFactory, order, authenticator, strategy);
         this.groupMembershipResolver = groupMembershipResolver;

--- a/src/main/java/org/cyverse/cas/ldap/rfc2307/config/Rfc2307LdapAuthenticationConfiguration.java
+++ b/src/main/java/org/cyverse/cas/ldap/rfc2307/config/Rfc2307LdapAuthenticationConfiguration.java
@@ -1,33 +1,32 @@
 package org.cyverse.cas.ldap.rfc2307.config;
 
 import com.google.common.collect.Multimap;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
+import org.apereo.cas.authentication.AuthenticationPasswordPolicyHandlingStrategy;
 import org.apereo.cas.authentication.CoreAuthenticationUtils;
 import org.apereo.cas.authentication.LdapAuthenticationHandler;
-import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
 import org.apereo.cas.authentication.principal.PrincipalNameTransformerUtils;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
-import org.apereo.cas.authentication.support.DefaultAccountStateHandler;
-import org.apereo.cas.authentication.support.DefaultLdapPasswordPolicyHandlingStrategy;
-import org.apereo.cas.authentication.support.GroovyLdapPasswordPolicyHandlingStrategy;
-import org.apereo.cas.authentication.support.LdapPasswordPolicyConfiguration;
-import org.apereo.cas.authentication.support.LdapPasswordPolicyHandlingStrategy;
-import org.apereo.cas.authentication.support.OptionalWarningAccountStateHandler;
+import org.apereo.cas.authentication.support.DefaultLdapAccountStateHandler;
+import org.apereo.cas.authentication.support.password.DefaultPasswordPolicyHandlingStrategy;
+import org.apereo.cas.authentication.support.password.GroovyPasswordPolicyHandlingStrategy;
+import org.apereo.cas.authentication.support.OptionalWarningLdapAccountStateHandler;
 import org.apereo.cas.authentication.support.RejectResultCodeLdapPasswordPolicyHandlingStrategy;
 import org.apereo.cas.authentication.support.password.PasswordEncoderUtils;
-import org.apereo.cas.config.LdapAuthenticationConfiguration;
+import org.apereo.cas.authentication.support.password.PasswordPolicyConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.configuration.model.core.authentication.PasswordPolicyProperties;
 import org.apereo.cas.configuration.model.support.ldap.LdapAuthenticationProperties;
+import org.apereo.cas.configuration.model.support.ldap.LdapPasswordPolicyProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.LdapUtils;
 import org.cyverse.cas.ldap.rfc2307.authentication.Rfc2307LdapAuthenticationHandler;
 import org.cyverse.cas.ldap.rfc2307.util.GroupMembershipResolver;
+import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.AuthenticationResponseHandler;
 import org.ldaptive.auth.Authenticator;
 import org.ldaptive.auth.ext.ActiveDirectoryAuthenticationResponseHandler;
@@ -46,57 +45,47 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.function.Predicate;
 
 /**
- * This class was copied and modified from {@link LdapAuthenticationConfiguration}, which is not designed
- * to be extended.
+ * This is {@link LdapAuthenticationConfiguration} that attempts to create
+ * relevant authentication handlers for LDAP.
+ *
+ * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
+ * @since 5.0.0
  */
 @Configuration("rfc2307LdapAuthenticationConfiguration")
 @EnableConfigurationProperties({CasConfigurationProperties.class, GroupMembershipProperties.class})
 public class Rfc2307LdapAuthenticationConfiguration {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Rfc2307LdapAuthenticationConfiguration.class);
+    private static final Logger LOGGER
+            = LoggerFactory.getLogger(Rfc2307LdapAuthenticationConfiguration.class);
 
+    @Autowired
     private CasConfigurationProperties casProperties;
 
+    @Autowired
     private GroupMembershipProperties groupMembershipProperties;
-
-    private PrincipalResolver personDirectoryPrincipalResolver;
-
-    private ServicesManager servicesManager;
-
-    @Autowired
-    public void setCasProperties(CasConfigurationProperties casProperties) {
-        this.casProperties = casProperties;
-    }
-
-    @Autowired
-    public void setGroupMembershipProperties(GroupMembershipProperties groupMembershipProperties) {
-        this.groupMembershipProperties = groupMembershipProperties;
-    }
 
     @Autowired
     @Qualifier("personDirectoryPrincipalResolver")
-    public void setPersonDirectoryPrincipalResolver(PrincipalResolver personDirectoryPrincipalResolver) {
-        this.personDirectoryPrincipalResolver = personDirectoryPrincipalResolver;
-    }
+    private PrincipalResolver personDirectoryPrincipalResolver;
 
     @Autowired
     @Qualifier("servicesManager")
-    public void setServicesManager(ServicesManager servicesManager) {
-        this.servicesManager = servicesManager;
-    }
+    private ServicesManager servicesManager;
 
     @ConditionalOnMissingBean(name = "ldapPrincipalFactory")
     @Bean
     public PrincipalFactory ldapPrincipalFactory() {
-        return new DefaultPrincipalFactory();
+        return PrincipalFactoryUtils.newPrincipalFactory();
     }
 
     @Bean
@@ -104,75 +93,70 @@ public class Rfc2307LdapAuthenticationConfiguration {
         final Collection<AuthenticationHandler> handlers = new HashSet<>();
 
         casProperties.getAuthn().getLdap()
-                .stream()
-                .filter(ldapInstanceConfigurationPredicate())
-                .forEach(l -> handlers.add(buildLdapAuthenticationHandler(l)));
+            .stream()
+            .filter(ldapInstanceConfigurationPredicate())
+            .forEach(l -> {
+                final Multimap<String, Object> multiMapAttributes =
+                    CoreAuthenticationUtils.transformPrincipalAttributesListIntoMultiMap(l.getPrincipalAttributeList());
+                LOGGER.debug("Created and mapped principal attributes [{}] for [{}]...", multiMapAttributes, l.getLdapUrl());
+
+                LOGGER.debug("Creating LDAP authenticator for [{}] and baseDn [{}]", l.getLdapUrl(), l.getBaseDn());
+                final Authenticator authenticator = LdapUtils.newLdaptiveAuthenticator(l);
+                LOGGER.debug("Ldap authenticator configured with return attributes [{}] for [{}] and baseDn [{}]",
+                    multiMapAttributes.keySet(), l.getLdapUrl(), l.getBaseDn());
+
+                LOGGER.debug("Creating group membership resolver for [{}]", l.getLdapUrl());
+                final GroupMembershipResolver groupMembershipResolver
+                        =  GroupMembershipResolver.fromConfig(l, groupMembershipProperties);
+
+                LOGGER.debug("Creating LDAP password policy handling strategy for [{}]", l.getLdapUrl());
+                final AuthenticationPasswordPolicyHandlingStrategy strategy = createLdapPasswordPolicyHandlingStrategy(l);
+
+                LOGGER.debug("Creating LDAP authentication handler for [{}]", l.getLdapUrl());
+                final LdapAuthenticationHandler handler = new Rfc2307LdapAuthenticationHandler(l.getName(),
+                    servicesManager, ldapPrincipalFactory(), l.getOrder(), authenticator, strategy, groupMembershipResolver);
+                handler.setCollectDnAttribute(l.isCollectDnAttribute());
+
+                final List<String> additionalAttributes = l.getAdditionalAttributes();
+                if (StringUtils.isNotBlank(l.getPrincipalAttributeId())) {
+                    additionalAttributes.add(l.getPrincipalAttributeId());
+                }
+                if (StringUtils.isNotBlank(l.getPrincipalDnAttributeName())) {
+                    handler.setPrincipalDnAttributeName(l.getPrincipalDnAttributeName());
+                }
+                handler.setAllowMultiplePrincipalAttributeValues(l.isAllowMultiplePrincipalAttributeValues());
+                handler.setAllowMissingPrincipalAttributeValue(l.isAllowMissingPrincipalAttributeValue());
+                handler.setPasswordEncoder(PasswordEncoderUtils.newPasswordEncoder(l.getPasswordEncoder()));
+                handler.setPrincipalNameTransformer(PrincipalNameTransformerUtils.newPrincipalNameTransformer(l.getPrincipalTransformation()));
+
+                if (StringUtils.isNotBlank(l.getCredentialCriteria())) {
+                    LOGGER.debug("Ldap authentication for [{}] is filtering credentials by [{}]",
+                        l.getLdapUrl(), l.getCredentialCriteria());
+                    handler.setCredentialSelectionPredicate(CoreAuthenticationUtils.newCredentialSelectionPredicate(l.getCredentialCriteria()));
+                }
+
+                if (StringUtils.isBlank(l.getPrincipalAttributeId())) {
+                    LOGGER.debug("No principal id attribute is found for LDAP authentication via [{}]", l.getLdapUrl());
+                } else {
+                    handler.setPrincipalIdAttribute(l.getPrincipalAttributeId());
+                    LOGGER.debug("Using principal id attribute [{}] for LDAP authentication via [{}]", l.getPrincipalAttributeId(), l.getLdapUrl());
+                }
+
+                final LdapPasswordPolicyProperties passwordPolicy = l.getPasswordPolicy();
+                if (passwordPolicy.isEnabled()) {
+                    LOGGER.debug("Password policy is enabled for [{}]. Constructing password policy configuration", l.getLdapUrl());
+                    final PasswordPolicyConfiguration cfg = createLdapPasswordPolicyConfiguration(passwordPolicy, authenticator, multiMapAttributes);
+                    handler.setPasswordPolicyConfiguration(cfg);
+                }
+
+                final Map<String, Object> attributes = CollectionUtils.wrap(multiMapAttributes);
+                handler.setPrincipalAttributeMap(attributes);
+
+                LOGGER.debug("Initializing LDAP authentication handler for [{}]", l.getLdapUrl());
+                handler.initialize();
+                handlers.add(handler);
+            });
         return handlers;
-    }
-
-    @SuppressWarnings("unchecked")
-    private LdapAuthenticationHandler buildLdapAuthenticationHandler(LdapAuthenticationProperties l) {
-        final Multimap<String, String> multiMapAttributes =
-                CoreAuthenticationUtils.transformPrincipalAttributesListIntoMultiMap(l.getPrincipalAttributeList());
-        LOGGER.debug("Created and mapped principal attributes [{}] for [{}]...", multiMapAttributes, l.getLdapUrl());
-
-        LOGGER.debug("Creating LDAP authenticator for [{}] and baseDn [{}]", l.getLdapUrl(), l.getBaseDn());
-        final Authenticator authenticator = LdapUtils.newLdaptiveAuthenticator(l);
-        LOGGER.debug("Ldap authenticator configured with return attributes [{}] for [{}] and baseDn [{}]",
-                multiMapAttributes.keySet(), l.getLdapUrl(), l.getBaseDn());
-
-        LOGGER.debug("Creating LDAP password policy handling strategy for [{}]", l.getLdapUrl());
-        final LdapPasswordPolicyHandlingStrategy strategy = createLdapPasswordPolicyHandlingStrategy(l);
-
-        LOGGER.debug("Creating group membership resolver for [{}]", l.getLdapUrl());
-        final GroupMembershipResolver groupMembershipResolver
-                = GroupMembershipResolver.fromConfig(l, groupMembershipProperties);
-
-        LOGGER.debug("Creating LDAP authentication handler for [{}]", l.getLdapUrl());
-        final LdapAuthenticationHandler handler = new Rfc2307LdapAuthenticationHandler(
-                l.getName(), servicesManager, ldapPrincipalFactory(), l.getOrder(), authenticator,
-                strategy, groupMembershipResolver);
-        handler.setCollectDnAttribute(l.isCollectDnAttribute());
-
-        final List<String> additionalAttributes = l.getAdditionalAttributes();
-        if (StringUtils.isNotBlank(l.getPrincipalAttributeId())) {
-            additionalAttributes.add(l.getPrincipalAttributeId());
-        }
-        if (StringUtils.isNotBlank(l.getPrincipalDnAttributeName())) {
-            handler.setPrincipalDnAttributeName(l.getPrincipalDnAttributeName());
-        }
-        handler.setAllowMultiplePrincipalAttributeValues(l.isAllowMultiplePrincipalAttributeValues());
-        handler.setAllowMissingPrincipalAttributeValue(l.isAllowMissingPrincipalAttributeValue());
-        handler.setPasswordEncoder(PasswordEncoderUtils.newPasswordEncoder(l.getPasswordEncoder()));
-        handler.setPrincipalNameTransformer(PrincipalNameTransformerUtils.newPrincipalNameTransformer(l.getPrincipalTransformation()));
-
-        if (StringUtils.isNotBlank(l.getCredentialCriteria())) {
-            LOGGER.debug("Ldap authentication for [{}] is filtering credentials by [{}]",
-                    l.getLdapUrl(), l.getCredentialCriteria());
-            handler.setCredentialSelectionPredicate(CoreAuthenticationUtils.newCredentialSelectionPredicate(l.getCredentialCriteria()));
-        }
-
-        if (StringUtils.isBlank(l.getPrincipalAttributeId())) {
-            LOGGER.debug("No principal id attribute is found for LDAP authentication via [{}]", l.getLdapUrl());
-        } else {
-            handler.setPrincipalIdAttribute(l.getPrincipalAttributeId());
-            LOGGER.debug("Using principal id attribute [{}] for LDAP authentication via [{}]", l.getPrincipalAttributeId(),
-                    l.getLdapUrl());
-        }
-
-        if (l.getPasswordPolicy().isEnabled()) {
-            LOGGER.debug("Password policy is enabled for [{}]. Constructing password policy configuration", l.getLdapUrl());
-            final LdapPasswordPolicyConfiguration
-                    cfg = createLdapPasswordPolicyConfiguration(l, authenticator, multiMapAttributes);
-            handler.setPasswordPolicyConfiguration(cfg);
-        }
-
-        final Map<String, Collection<String>> attributes = CollectionUtils.wrap(multiMapAttributes);
-        handler.setPrincipalAttributeMap(attributes);
-
-        LOGGER.debug("Initializing LDAP authentication handler for [{}]", l.getLdapUrl());
-        handler.initialize();
-        return handler;
     }
 
 
@@ -190,43 +174,41 @@ public class Rfc2307LdapAuthenticationConfiguration {
         };
     }
 
-    private LdapPasswordPolicyHandlingStrategy createLdapPasswordPolicyHandlingStrategy(final LdapAuthenticationProperties l) {
-        if (l.getPasswordPolicy().getStrategy() == PasswordPolicyProperties.PasswordPolicyHandlingOptions.REJECT_RESULT_CODE) {
+    private AuthenticationPasswordPolicyHandlingStrategy<AuthenticationResponse, PasswordPolicyConfiguration>
+        createLdapPasswordPolicyHandlingStrategy(final LdapAuthenticationProperties l) {
+        if (l.getPasswordPolicy().getStrategy() == LdapPasswordPolicyProperties.PasswordPolicyHandlingOptions.REJECT_RESULT_CODE) {
             LOGGER.debug("Created LDAP password policy handling strategy based on blacklisted authentication result codes");
             return new RejectResultCodeLdapPasswordPolicyHandlingStrategy();
         }
 
         final Resource location = l.getPasswordPolicy().getGroovy().getLocation();
-        if (l.getPasswordPolicy().getStrategy() == PasswordPolicyProperties.PasswordPolicyHandlingOptions.GROOVY && location != null) {
+        if (l.getPasswordPolicy().getStrategy() == LdapPasswordPolicyProperties.PasswordPolicyHandlingOptions.GROOVY && location != null) {
             LOGGER.debug("Created LDAP password policy handling strategy based on Groovy script [{}]", location);
-            return new GroovyLdapPasswordPolicyHandlingStrategy(location);
+            return new GroovyPasswordPolicyHandlingStrategy(location);
         }
 
         LOGGER.debug("Created default LDAP password policy handling strategy");
-        return new DefaultLdapPasswordPolicyHandlingStrategy();
+        return new DefaultPasswordPolicyHandlingStrategy();
     }
 
-    @SuppressWarnings("unchecked")
-    private LdapPasswordPolicyConfiguration createLdapPasswordPolicyConfiguration(final LdapAuthenticationProperties l,
-                                                                                  final Authenticator authenticator,
-                                                                                  final Multimap<String, String> attributes) {
-        final LdapPasswordPolicyConfiguration cfg = new LdapPasswordPolicyConfiguration(l.getPasswordPolicy());
+    private PasswordPolicyConfiguration createLdapPasswordPolicyConfiguration(final LdapPasswordPolicyProperties passwordPolicy,
+                                                                              final Authenticator authenticator,
+                                                                              final Multimap<String, Object> attributes) {
+        final PasswordPolicyConfiguration cfg = new PasswordPolicyConfiguration(passwordPolicy);
         final Set<AuthenticationResponseHandler> handlers = new HashSet<>();
 
-        final String customPolicyClass = l.getPasswordPolicy().getCustomPolicyClass();
+        final String customPolicyClass = passwordPolicy.getCustomPolicyClass();
         if (StringUtils.isNotBlank(customPolicyClass)) {
             try {
-                LOGGER.debug("Configuration indicates use of a custom password policy handler [{}]",
-                        customPolicyClass);
-                final Class<AuthenticationResponseHandler> clazz = (Class<AuthenticationResponseHandler>)
-                        Class.forName(customPolicyClass);
+                LOGGER.debug("Configuration indicates use of a custom password policy handler [{}]", customPolicyClass);
+                final Class<AuthenticationResponseHandler> clazz = (Class<AuthenticationResponseHandler>) Class.forName(customPolicyClass);
                 handlers.add(clazz.getDeclaredConstructor().newInstance());
             } catch (final Exception e) {
                 LOGGER.warn("Unable to construct an instance of the password policy handler", e);
             }
         }
-        LOGGER.debug("Password policy authentication response handler is set to accommodate directory type: [{}]", l.getPasswordPolicy().getType());
-        switch (l.getPasswordPolicy().getType()) {
+        LOGGER.debug("Password policy authentication response handler is set to accommodate directory type: [{}]", passwordPolicy.getType());
+        switch (passwordPolicy.getType()) {
             case AD:
                 handlers.add(new ActiveDirectoryAuthenticationResponseHandler(Period.ofDays(cfg.getPasswordWarningNumberOfDays())));
                 Arrays.stream(ActiveDirectoryAuthenticationResponseHandler.ATTRIBUTES).forEach(a -> {
@@ -240,7 +222,7 @@ public class Rfc2307LdapAuthenticationConfiguration {
                     attributes.put(a, a);
                 });
                 handlers.add(new FreeIPAAuthenticationResponseHandler(
-                        Period.ofDays(cfg.getPasswordWarningNumberOfDays()), cfg.getLoginFailures()));
+                    Period.ofDays(cfg.getPasswordWarningNumberOfDays()), cfg.getLoginFailures()));
                 break;
             case EDirectory:
                 Arrays.stream(EDirectoryAuthenticationResponseHandler.ATTRIBUTES).forEach(a -> {
@@ -254,24 +236,25 @@ public class Rfc2307LdapAuthenticationConfiguration {
                 handlers.add(new PasswordExpirationAuthenticationResponseHandler());
                 break;
         }
-        authenticator.setAuthenticationResponseHandlers((AuthenticationResponseHandler[]) handlers.toArray(new AuthenticationResponseHandler[handlers.size()]));
+        authenticator.setAuthenticationResponseHandlers((AuthenticationResponseHandler[]) handlers.toArray(new AuthenticationResponseHandler[0]));
 
         LOGGER.debug("LDAP authentication response handlers configured are: [{}]", handlers);
 
-        if (StringUtils.isNotBlank(l.getPasswordPolicy().getWarningAttributeName())
-                && StringUtils.isNotBlank(l.getPasswordPolicy().getWarningAttributeValue())) {
-
-            final OptionalWarningAccountStateHandler accountHandler = new OptionalWarningAccountStateHandler();
-            accountHandler.setDisplayWarningOnMatch(l.getPasswordPolicy().isDisplayWarningOnMatch());
-            accountHandler.setWarnAttributeName(l.getPasswordPolicy().getWarningAttributeName());
-            accountHandler.setWarningAttributeValue(l.getPasswordPolicy().getWarningAttributeValue());
-            accountHandler.setAttributesToErrorMap(l.getPasswordPolicy().getPolicyAttributes());
+        if (!passwordPolicy.isAccountStateHandlingEnabled()) {
+            cfg.setAccountStateHandler((response, configuration) -> new ArrayList<>(0));
+            LOGGER.debug("Handling LDAP account states is disabled via CAS configuration");
+        } else if (StringUtils.isNotBlank(passwordPolicy.getWarningAttributeName()) && StringUtils.isNotBlank(passwordPolicy.getWarningAttributeValue())) {
+            final OptionalWarningLdapAccountStateHandler accountHandler = new OptionalWarningLdapAccountStateHandler();
+            accountHandler.setDisplayWarningOnMatch(passwordPolicy.isDisplayWarningOnMatch());
+            accountHandler.setWarnAttributeName(passwordPolicy.getWarningAttributeName());
+            accountHandler.setWarningAttributeValue(passwordPolicy.getWarningAttributeValue());
+            accountHandler.setAttributesToErrorMap(passwordPolicy.getPolicyAttributes());
             cfg.setAccountStateHandler(accountHandler);
             LOGGER.debug("Configuring an warning account state handler for LDAP authentication for warning attribute [{}] and value [{}]",
-                    l.getPasswordPolicy().getWarningAttributeName(), l.getPasswordPolicy().getWarningAttributeValue());
+                passwordPolicy.getWarningAttributeName(), passwordPolicy.getWarningAttributeValue());
         } else {
-            final DefaultAccountStateHandler accountHandler = new DefaultAccountStateHandler();
-            accountHandler.setAttributesToErrorMap(l.getPasswordPolicy().getPolicyAttributes());
+            final DefaultLdapAccountStateHandler accountHandler = new DefaultLdapAccountStateHandler();
+            accountHandler.setAttributesToErrorMap(passwordPolicy.getPolicyAttributes());
             cfg.setAccountStateHandler(accountHandler);
             LOGGER.debug("Configuring the default account state handler for LDAP authentication");
         }


### PR DESCRIPTION
The strategy that I followed with this migration was to copy code from CAS 5.3.7 and make changes similar to the changes that I made for CAS 5.2.x.